### PR TITLE
Fix link api error handling

### DIFF
--- a/pkg/link/link_api.go
+++ b/pkg/link/link_api.go
@@ -23,7 +23,7 @@ func ConfigureAPI(environment config.Environment) error {
 	if err != nil {
 		return err
 	}
-	baseURL, _ := getConfigureBaseURL()
+	baseURL, err := getConfigureBaseURL()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This line currently checks the same error twice and ignores anything
from `getConfigureURL` -- remove the wildcard `_`.